### PR TITLE
Updated Lab 7 Reflection Question Links

### DIFF
--- a/Instructions/Labs/Lab-7-Customizing-Copilot.md
+++ b/Instructions/Labs/Lab-7-Customizing-Copilot.md
@@ -109,7 +109,7 @@ __Instructions:__
 
 - A more limited feature utilizing custom instructions is the [path-specific custom instructions file](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions#creating-path-specific-custom-instructions-1). How might these be beneficial over more general repository instruction sets?
 - What are some prompts you might be using in your daily workflow that can be consolidated into an instructions file?
-- A _Public Preview_ feature similar to custom instructions files is [prompt files](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions#enabling-and-using-prompt-files). How might you use these in conjunction with or separately from custom instructions files?
+- A _Public Preview_ feature similar to custom instructions files is [prompt files](https://code.visualstudio.com/docs/copilot/customization/prompt-files). How might you use these in conjunction with or separately from custom instructions files?
 
 ### 🎯 Key Takeaways
 


### PR DESCRIPTION
Before, both links in lab 7's _Reflection Questions_ section headed to the same page (https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions) but were supposed to navigate to different HTML IDs. 

The second of these two links discussing prompt files now links to a VS Code documentation link, which should provide similar extended learning while being more clear on the particular focus.